### PR TITLE
Updated to support fake cigar like xSyN

### DIFF
--- a/lib/bamtools-2.3.0/src/api/internal/bam/BamReader_p.cpp
+++ b/lib/bamtools-2.3.0/src/api/internal/bam/BamReader_p.cpp
@@ -270,7 +270,7 @@ static inline int hts_reg2bin(int64_t beg, int64_t end, int min_shift, int n_lvl
 
 bool BamReaderPrivate::Tag2Cigar(BamAlignment &a, RaiiBuffer &buf)
 {
-    if (a.RefID < 0 || a.Position < 0 || a.SupportData.NumCigarOperations != 1) return false;
+    if (a.RefID < 0 || a.Position < 0 || a.SupportData.NumCigarOperations == 0) return false;
 
     const unsigned char *data = (const unsigned char*)buf.Buffer;
     const unsigned data_len = a.SupportData.BlockLength - Constants::BAM_CORE_SIZE;
@@ -299,8 +299,9 @@ bool BamReaderPrivate::Tag2Cigar(BamAlignment &a, RaiiBuffer &buf)
     a.Bin = hts_reg2bin(a.Position, alignment_end, 14, 5);
 
     // populate new AllCharData
+    int fake_bytes = a.SupportData.NumCigarOperations * 4;
     std::string new_data;
-    new_data.reserve(data_len - 12 + 1);
+    new_data.reserve(data_len - 8 - fake_bytes + 1);
     new_data.append((char*)data, a.SupportData.QueryNameLength); // query name
     new_data.append((char*)data + tag_cigar_offset, tag_cigar_len * 4); // real CIGAR
     new_data.append((char*)data + seq_offset, tag_cigar_offset - 8 - seq_offset); // seq, qual and tags before CG
@@ -310,8 +311,8 @@ bool BamReaderPrivate::Tag2Cigar(BamAlignment &a, RaiiBuffer &buf)
 
     // update member variables
     a.SupportData.NumCigarOperations = tag_cigar_len;
-    a.SupportData.BlockLength -= 12;
-    memcpy(buf.Buffer, new_data.c_str(), buf.NumBytes - 12);
+    a.SupportData.BlockLength -= 8 + fake_bytes;
+    memcpy(buf.Buffer, new_data.c_str(), buf.NumBytes - 8 - fake_bytes);
     return true;
 }
 

--- a/lib/bamtools-2.3.0/src/api/internal/bam/BamReader_p.cpp
+++ b/lib/bamtools-2.3.0/src/api/internal/bam/BamReader_p.cpp
@@ -367,8 +367,8 @@ bool BamReaderPrivate::LoadNextAlignment(BamAlignment& alignment) {
 
     if ( m_stream.Read(allCharData.Buffer, dataLength) == dataLength ) {
 
-        if (Tag2Cigar(alignment, allCharData))
-            dataLength -= 12;
+        int OldNumCigarOperations = alignment.SupportData.NumCigarOperations;
+        if (Tag2Cigar(alignment, allCharData)) dataLength -= 8 + OldNumCigarOperations * 4;
 
         // store 'allCharData' in supportData structure
         alignment.SupportData.AllCharData.assign((const char*)allCharData.Buffer, dataLength);

--- a/lib/bamtools-2.3.0/src/api/internal/bam/BamWriter_p.cpp
+++ b/lib/bamtools-2.3.0/src/api/internal/bam/BamWriter_p.cpp
@@ -238,7 +238,7 @@ void BamWriterPrivate::WriteAlignment(const BamAlignment& al) {
                                        tagDataLength;
     unsigned int blockSize = Constants::BAM_CORE_SIZE + dataBlockSize;
     if (numCigarOperations >= 65536)
-        blockSize += 12;
+        blockSize += 16;
     if ( m_isBigEndian ) BamTools::SwapEndian_32(blockSize);
     m_stream.Write((char*)&blockSize, Constants::BAM_SIZEOF_INT);
 
@@ -247,7 +247,7 @@ void BamWriterPrivate::WriteAlignment(const BamAlignment& al) {
     buffer[0] = al.RefID;
     buffer[1] = al.Position;
     buffer[2] = (alignmentBin << 16) | (al.MapQuality << 8) | nameLength;
-    buffer[3] = (al.AlignmentFlag << 16) | (numCigarOperations < 65536? numCigarOperations : 1);
+    buffer[3] = (al.AlignmentFlag << 16) | (numCigarOperations < 65536? numCigarOperations : 2);
     buffer[4] = queryLength;
     buffer[5] = al.MateRefID;
     buffer[6] = al.MatePosition;
@@ -280,9 +280,14 @@ void BamWriterPrivate::WriteAlignment(const BamAlignment& al) {
         else
             m_stream.Write(packedCigar.data(), packedCigarLength);
     } else {
-        unsigned int cigar1 = queryLength << 4 | 4;
-        if (m_isBigEndian) BamTools::SwapEndian_32(cigar1);
-        m_stream.Write((char*)&cigar1, 4);
+        unsigned int cigar[2];
+        cigar[0] = queryLength << 4 | 4;
+        cigar[1] = (al.GetEndPosition() - al.Position) << 4 | 3;
+        if (m_isBigEndian) {
+            BamTools::SwapEndian_32(cigar[0]);
+            BamTools::SwapEndian_32(cigar[1]);
+        }
+        m_stream.Write((char*)cigar, 8);
     }
 
     if ( queryLength > 0 ) {
@@ -428,7 +433,7 @@ void BamWriterPrivate::WriteCoreAlignment(const BamAlignment& al) {
     // write the block size
     unsigned int blockSize = al.SupportData.BlockLength;
     if (al.SupportData.NumCigarOperations >= 65536)
-        blockSize += 12;
+        blockSize += 16;
     if ( m_isBigEndian ) BamTools::SwapEndian_32(blockSize);
     m_stream.Write((char*)&blockSize, Constants::BAM_SIZEOF_INT);
 
@@ -440,7 +445,7 @@ void BamWriterPrivate::WriteCoreAlignment(const BamAlignment& al) {
     buffer[0] = al.RefID;
     buffer[1] = al.Position;
     buffer[2] = (alignmentBin << 16) | (al.MapQuality << 8) | al.SupportData.QueryNameLength;
-    buffer[3] = (al.AlignmentFlag << 16) | (al.SupportData.NumCigarOperations < 65536? al.SupportData.NumCigarOperations : 1);
+    buffer[3] = (al.AlignmentFlag << 16) | (al.SupportData.NumCigarOperations < 65536? al.SupportData.NumCigarOperations : 2);
     buffer[4] = al.SupportData.QuerySequenceLength;
     buffer[5] = al.MateRefID;
     buffer[6] = al.MatePosition;
@@ -464,10 +469,15 @@ void BamWriterPrivate::WriteCoreAlignment(const BamAlignment& al) {
         const unsigned data_len = al.SupportData.BlockLength - Constants::BAM_CORE_SIZE;
         const unsigned cigar_offset = al.SupportData.QueryNameLength;
         const unsigned seq_offset = cigar_offset + al.SupportData.NumCigarOperations * 4;
-        unsigned fake_cigar = al.SupportData.QuerySequenceLength << 4 | 4;
+        unsigned fake_cigar[2];
+        fake_cigar[0] = al.SupportData.QuerySequenceLength << 4 | 4;
+        fake_cigar[1] = (al.GetEndPosition() - al.Position) << 4 | 3;
         m_stream.Write(data, al.SupportData.QueryNameLength);
-        if (m_isBigEndian) BamTools::SwapEndian_32(fake_cigar);
-        m_stream.Write((char*)&fake_cigar, 4);
+        if (m_isBigEndian) {
+            BamTools::SwapEndian_32(fake_cigar[0]);
+            BamTools::SwapEndian_32(fake_cigar[1]);
+        }
+        m_stream.Write((char*)&fake_cigar, 8);
         m_stream.Write(data + seq_offset, data_len - seq_offset);
         m_stream.Write("CGBI", 4);
         if (m_isBigEndian) {


### PR DESCRIPTION
The final decision on the long cigar is to encode a fake cigar with `<readLen>S<refLen>N`. This commit enables bamtools-2.3.0 to recognize both `<readLen>S` and `<readLen>S<refLen>N` (more precisely, this commit works with all fake cigars whose first operation clips the entire read). samtools/htslib#560 has been merged via samtools/htslib@aea349a. It implements long-cigar support the same way. Now the default htslib branch works with long cigar and ngmlr --bam-fix output.