### PR TITLE
Pointer to Debian/Ubuntu+Conda for readily installable packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Note Mac users often have to provide parameters to the cmake command:
 <pre>cmake -D CMAKE_C_COMPILER=/opt/local/bin/gcc-mp-4.7 -D CMAKE_CXX_COMPILER=/opt/local/bin/g++-mp-4.7 .. 
 </pre>
 
+# Readily installable packages of Sniffles
+[Debian](https://tracker.debian.org/pkg/sniffles) and [Ubuntu](https://launchpad.net/ubuntu/+source/sniffles) provide packages of Sniffles. These can be installed directly on your computer just like any other package or be added to a Docker/Singularity image across all major platforms.
+
+Sniffles can also be installed with [Conda](https://anaconda.org/bioconda/sniffles).
 
 **************************************
 ## NGMLR


### PR DESCRIPTION
Hello,

Debian ships a package of Sniffles for a while and recently also a package of NGMLR was added. Conda also offers it. Maybe this is helpful for your users.

The build test we run is "bin/sniffles-*/sniffles -m test_set/reads_region.bam -v test.vcf". This could likely be extended. We can now also run automated build tests after the package was installed as a regular Debian package, i.e. not only in the source tree. And this may demand for additional packages to be installed. If there are ideas/wishes from your side what we should run for you to trust our packaging, this would be helpful to develop our packaging further.

Many thanks and regards,
Steffen