### PR TITLE
Compiler warnings int vs long int

### DIFF
--- a/src/print/VCFPrinter.cpp
+++ b/src/print/VCFPrinter.cpp
@@ -369,16 +369,16 @@ void VCFPrinter::print_body(Breakpoint * &SV, RefVector ref) {
 
 			if (((SV->get_SVtype() & INS) && SV->get_length() == Parameter::Instance()->huge_ins) && SV->get_types().is_ALN) {
 				if (SV->get_sequence().size() != 0) { //!
-					fprintf(file, "%i", SV->get_sequence().size());
+					fprintf(file, "%li", SV->get_sequence().size());
 				} else {
 					fprintf(file, "%i", 1);
 				}
 			} else if (SV->get_SVtype() & TRA) {
 				fprintf(file, "%i", 1);
 			} else if (SV->get_SVtype() & DEL) {
-				fprintf(file, "%i", SV->get_length() * -1);
+				fprintf(file, "%li", SV->get_length() * -1);
 			} else {
-				fprintf(file, "%i", SV->get_length());
+				fprintf(file, "%li", SV->get_length());
 			}
 			//	}
 			fprintf(file, "%s", ";STRANDS=");
@@ -510,7 +510,7 @@ void VCFPrinter::print_body_recall(Breakpoint * &SV, RefVector ref) {
 	if (((SV->get_SVtype() & INS) && SV->get_length() == Parameter::Instance()->huge_ins) && !SV->get_types().is_SR) {
 		fprintf(file, "%s", "NA");
 	} else {
-		fprintf(file, "%i", SV->get_length());
+		fprintf(file, "%li", SV->get_length());
 	}
 	//	}
 	fprintf(file, "%s", ";STRANDS=");


### PR DESCRIPTION
```
cd /home/moeller/git/med-team/sniffles/obj-x86_64-linux-gnu/src && /usr/bin/c++   -I/usr/include/bamtools -I/home/moeller/git/med-team/sniffles/src/../lib/bamtools-2.3.0/src -I/home/moeller/git/med-team/sniffles/src/../lib/tclap-1.2.1/include  -g -O2 -fdebug-prefix-map=/home/moeller/git/med-team/sniffles=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fopenmp   -o CMakeFiles/sniffles.dir/print/BedpePrinter.cpp.o -c /home/moeller/git/med-team/sniffles/src/print/BedpePrinter.cpp
/home/moeller/git/med-team/sniffles/src/print/BedpePrinter.cpp: In member function ‘virtual void BedpePrinter::print_body(Breakpoint*&, BamTools::RefVector)’:
/home/moeller/git/med-team/sniffles/src/print/BedpePrinter.cpp:99:21: warning: format ‘%i’ expects argument of type ‘int’, but argument 3 has type ‘long int’ [-Wformat=]
   99 |     fprintf(file, "%i", SV->get_length());
      |                    ~^   ~~~~~~~~~~~~~~~~
      |                     |                 |
      |                     int               long int
      |                    %li
/home/moeller/git/med-team/sniffles/src/print/BedpePrinter.cpp: In member function ‘virtual void BedpePrinter::print_body_recall(Breakpoint*&, BamTools::RefVector)’:
/home/moeller/git/med-team/sniffles/src/print/BedpePrinter.cpp:123:18: warning: format ‘%i’ expects argument of type ‘int’, but argument 3 has type ‘long int’ [-Wformat=]
  123 |  fprintf(file, "%i", IPrinter::calc_pos(SV->get_coordinates().start.max_pos, ref, chr));
      |                 ~^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                  |                     |
      |                  int                   long int
      |                 %li
/home/moeller/git/med-team/sniffles/src/print/BedpePrinter.cpp:130:18: warning: format ‘%i’ expects argument of type ‘int’, but argument 3 has type ‘long int’ [-Wformat=]
  130 |  fprintf(file, "%i", IPrinter::calc_pos(SV->get_coordinates().stop.max_pos, ref, chr));
      |                 ~^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                  |                     |
      |                  int                   long int
      |                 %li
/home/moeller/git/med-team/sniffles/src/print/BedpePrinter.cpp:158:19: warning: format ‘%i’ expects argument of type ‘int’, but argument 3 has type ‘long int’ [-Wformat=]
  158 |   fprintf(file, "%i", SV->get_length());
      |                  ~^   ~~~~~~~~~~~~~~~~
      |                   |                 |
      |                   int               long int
      |                  %li
```