### PR TITLE
Compiler warning long long -> long

### DIFF
--- a/src/realign/SWCPU.cpp
+++ b/src/realign/SWCPU.cpp
@@ -27,7 +27,7 @@ SWCPUCor::SWCPUCor(int gpu_id) {
 	long maxLen = (long) 100000 * (long) 20000;
 	alignMatrix = new MatrixElement[maxLen];
 
-	fprintf(stderr, "Allocationg: %llu\n", maxLen * sizeof(MatrixElement));
+	fprintf(stderr, "Allocationg: %lu\n", maxLen * sizeof(MatrixElement));
 
 	binaryCigar = new int[200000];
 


### PR DESCRIPTION
```
cd /home/moeller/git/med-team/sniffles/obj-x86_64-linux-gnu/src && /usr/bin/c++   -I/usr/include/bamtools -I/home/moeller/git/med-team/sniffles/src/../lib/bamtools-2.3.0/src -I/home/moeller/git/med-team/sniffles/src/../lib/tclap-1.2.1/include  -g -O2 -fdebug-prefix-map=/home/moeller/git/med-team/sniffles=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fopenmp   -o CMakeFiles/sniffles.dir/realign/SWCPU.cpp.o -c /home/moeller/git/med-team/sniffles/src/realign/SWCPU.cpp
/home/moeller/git/med-team/sniffles/src/realign/SWCPU.cpp: In constructor ‘SWCPUCor::SWCPUCor(int)’:
/home/moeller/git/med-team/sniffles/src/realign/SWCPU.cpp:30:35: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 3 has type ‘long unsigned int’ [-Wformat=]
   30 |  fprintf(stderr, "Allocationg: %llu\n", maxLen * sizeof(MatrixElement));
      |                                ~~~^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                   |            |
      |                                   |            long unsigned int
      |                                   long long unsigned int
      |                                %lu
```