### PR TITLE
Added return instruction to recursive invocation

### DIFF
--- a/src/tree/Intervall_bed.cpp
+++ b/src/tree/Intervall_bed.cpp
@@ -80,13 +80,12 @@ bool IntervallTree_bed::is_in(long position, Leaf * &p) {
 	} else {
 		long score = p->overlap(position);
 		if (score > 0) {
-			is_in(position, p->left);
+			return is_in(position, p->left);
 		} else if (score < 0) {
-			is_in(position, p->right);
+			return is_in(position, p->right);
 		} else {
 			return true;
 		}
-
 	}
 }
 // Copy a tree


### PR DESCRIPTION
Hello,
These new C++ versions freak me out, and it likely would be just fine in R - please forgive an old timer here, at least the compiler also warns:
```
cd /home/moeller/git/med-team/sniffles/obj-x86_64-linux-gnu/src && /usr/bin/c++   -I/usr/include/bamtools -I/home/moeller/git/med-team/sniffles/src/../lib/bamtools-2.3.0/src -I/home/moeller/git/med-team/sniffles/src/../lib/tclap-1.2.1/include  -g -O2 -fdebug-prefix-map=/home/moeller/git/med-team/sniffles=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fopenmp   -o CMakeFiles/sniffles.dir/tree/Intervall_bed.cpp.o -c /home/moeller/git/med-team/sniffles/src/tree/Intervall_bed.cpp
/home/moeller/git/med-team/sniffles/src/tree/Intervall_bed.cpp: In member function ‘bool IntervallTree_bed::is_in(long int, Leaf*&)’:
/home/moeller/git/med-team/sniffles/src/tree/Intervall_bed.cpp:91:1: warning: control reaches end of non-void function [-Wreturn-type]
   91 | }
      | ^
```
_If_ this was a bug then this it is a rather dominant one, I presume.
Best,
Steffen