### PR TITLE
Non-zero exit code in fatal_error_main()

### DIFF
--- a/src/sniffles/util.py
+++ b/src/sniffles/util.py
@@ -96,7 +96,7 @@ def fatal_error(msg):
 
 def fatal_error_main(msg):
     error(msg+" (Fatal error, exiting.)")
-    raise Sniffles2Exit
+    sys.exit(1)
 
 def load_tandem_repeats(filename,padding):
     contigs_tr={}


### PR DESCRIPTION
I don't know what the purpose of the Sniffles2Exit is/was, but this PR should fix the issue raised in https://github.com/fritzsedlazeck/Sniffles/issues/314