### PR TITLE
Fix missing genotype headers in genotyping(force call) mode

### DIFF
--- a/src/sniffles/parallel.py
+++ b/src/sniffles/parallel.py
@@ -36,8 +36,10 @@ class Task:
 
     def build_leadtab(self,config):
         assert(self.lead_provider==None)
-
-        self.bam=pysam.AlignmentFile(config.input, config.input_mode, require_index=True)
+        if config.input_is_cram == True and config.reference is not None:
+            self.bam=pysam.AlignmentFile(config.input, config.input_mode, require_index=True,reference_filename =config.reference)
+        else:
+            self.bam=pysam.AlignmentFile(config.input, config.input_mode, require_index=True)
         self.lead_provider=leadprov.LeadProvider(config,self.id*config.task_read_id_offset_mult)
         externals=self.lead_provider.build_leadtab(self.contig,self.start,self.end,self.bam)
         return externals,self.lead_provider.read_count

--- a/src/sniffles/vcf.py
+++ b/src/sniffles/vcf.py
@@ -333,13 +333,13 @@ class VCF:
                     has_gt_headers[gt] = True
         
         if not has_gt_headers["GT"]:
-            header_lines.insert(len(header_lines),'##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">')
+            header_lines.insert(len(header_lines)-2,'##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">')
         if not has_gt_headers["GQ"]:
-            header_lines.insert(len(header_lines),'##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">')
+            header_lines.insert(len(header_lines)-2,'##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">')
         if not has_gt_headers["DR"]:
-            header_lines.insert(len(header_lines),'##FORMAT=<ID=DR,Number=1,Type=Integer,Description="Number of reference reads">')
+            header_lines.insert(len(header_lines)-2,'##FORMAT=<ID=DR,Number=1,Type=Integer,Description="Number of reference reads">')
         if not has_gt_headers["DV"]:
-            header_lines.insert(len(header_lines),'##FORMAT=<ID=DV,Number=1,Type=Integer,Description="Number of variant reads">')
+            header_lines.insert(len(header_lines)-2,'##FORMAT=<ID=DV,Number=1,Type=Integer,Description="Number of variant reads">')
 
         self.write_raw("\n".join(header_lines),endl="")
 

--- a/src/sniffles/vcf.py
+++ b/src/sniffles/vcf.py
@@ -317,6 +317,29 @@ class VCF:
         header_lines.insert(1,'##genotypeFileDate="'+self.config.start_date+'"')
         header_lines.insert(1,'##genotypeCommand="'+self.config.command+'"')
         header_lines.insert(1,f"##genotypeSource={self.config.version}_{self.config.build}")
+
+        # Fix missing genotype headers errors when reading input vcf in genotype mode.
+        # This error will happen when input vcf does not have GT,GQ,DR,DV headers.
+        # Some tools such as turvari will throw errors when processing the output vcf.
+        has_gt_headers = {
+            "GT":False,
+            "GQ":False,
+            "DR":False,
+            "DV":False,
+        }
+        for header_line in header_lines:
+            for gt in has_gt_headers.keys():
+                if "##FORMAT=<ID="+gt+"," in header_line:
+                    has_gt_headers[gt] = True
+        if has_gt_headers["GT"]:
+            header_lines.append('##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">')
+        if has_gt_headers["GQ"]:
+            header_lines.append('##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">')
+        if has_gt_headers["DR"]:
+            header_lines.append('##FORMAT=<ID=DR,Number=1,Type=Integer,Description="Number of reference reads">')
+        if has_gt_headers["DV"]:
+            header_lines.append('##FORMAT=<ID=DV,Number=1,Type=Integer,Description="Number of variant reads">')
+
         self.write_raw("\n".join(header_lines),endl="")
 
     def close(self):

--- a/src/sniffles/vcf.py
+++ b/src/sniffles/vcf.py
@@ -331,14 +331,15 @@ class VCF:
             for gt in has_gt_headers.keys():
                 if "##FORMAT=<ID="+gt+"," in header_line:
                     has_gt_headers[gt] = True
-        if has_gt_headers["GT"]:
-            header_lines.append('##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">')
-        if has_gt_headers["GQ"]:
-            header_lines.append('##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">')
-        if has_gt_headers["DR"]:
-            header_lines.append('##FORMAT=<ID=DR,Number=1,Type=Integer,Description="Number of reference reads">')
-        if has_gt_headers["DV"]:
-            header_lines.append('##FORMAT=<ID=DV,Number=1,Type=Integer,Description="Number of variant reads">')
+        
+        if not has_gt_headers["GT"]:
+            header_lines.insert(len(header_lines),'##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">')
+        if not has_gt_headers["GQ"]:
+            header_lines.insert(len(header_lines),'##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype quality">')
+        if not has_gt_headers["DR"]:
+            header_lines.insert(len(header_lines),'##FORMAT=<ID=DR,Number=1,Type=Integer,Description="Number of reference reads">')
+        if not has_gt_headers["DV"]:
+            header_lines.insert(len(header_lines),'##FORMAT=<ID=DV,Number=1,Type=Integer,Description="Number of variant reads">')
 
         self.write_raw("\n".join(header_lines),endl="")
 


### PR DESCRIPTION
Fix errors related to missing genotype headers in genotype mode when processing certain input VCF files. This error occurs when the input VCF lacks GT, GQ, DR, and DV headers. Some tools, like Turvari, may encounter errors when working with the those VCF files.

The errors returned by Truvari are:

```
[W::vcf_parse_format] FORMAT 'GQ' at 1:125276 is not defined in the header, assuming Type=String
[W::vcf_parse_format] FORMAT 'DR' at 1:125276 is not defined in the header, assuming Type=String
[W::vcf_parse_format] FORMAT 'DV' at 1:125276 is not defined in the header, assuming Type=String
[W::vcf_parse_format] FORMAT 'GQ' at 1:125276 is not defined in the header, assuming Type=String
[W::vcf_parse_format] FORMAT 'DR' at 1:125276 is not defined in the header, assuming Type=String
[W::vcf_parse_format] FORMAT 'DV' at 1:125276 is not defined in the header, assuming Type=String
[E::bcf_translate] Unchecked error (2 Tag not defined in header) at 1:125276, exiting
```

Also mentioned in Issue #449 