### PR TITLE
fix setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires:
 scripts:
     src/sniffles/sniffles
 
-[options.extras_requires]
+[options.extras_require]
 align =
     edlib>=1.3.9
 mem =


### PR DESCRIPTION
Fixes a typo that gave a somewhat cryptic error when installing via `pip install .`
```
  Getting requirements to build editable ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [31 lines of output]
      Traceback (most recent call last):
        File "python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])

...
        File "/tmp/pip-build-env-v9w6gfbw/overlay/lib/python3.11/site-packages/setuptools/config/setupcfg.py", line 496, in parse
          raise OptionError(
      distutils.errors.DistutilsOptionError: Unsupported distribution option section: [options.extras_requires]
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error
```