### PR TITLE
fix parallelism for osx

### DIFF
--- a/src/sniffles/sniffles
+++ b/src/sniffles/sniffles
@@ -10,6 +10,7 @@
 #
 import logging
 import logging.config
+import multiprocessing
 from typing import Optional
 
 from sniffles.utils.resmon import ResourceMonitor
@@ -70,6 +71,8 @@ def Sniffles2_Main(processes: list[parallel.SnifflesWorker]):
 
     input_ext = [f.split(".")[-1].lower() for f in config.input]
 
+    # needed for running on osx
+    multiprocessing.set_start_method("fork")
     if len(set(input_ext)) > 1:
         util.fatal_error_main(f"Please specify either: A single .bam/.cram file - OR - one or more .snf files - OR - a single .tsv file containing a list of .snf files and optional sample ids as input. (supplied were: {list(set(input_ext))})")
 

--- a/src/sniffles/sniffles
+++ b/src/sniffles/sniffles
@@ -72,7 +72,9 @@ def Sniffles2_Main(processes: list[parallel.SnifflesWorker]):
     input_ext = [f.split(".")[-1].lower() for f in config.input]
 
     # needed for running on osx
-    multiprocessing.set_start_method("fork")
+    if sys.platform == "darwin":
+        multiprocessing.set_start_method("fork")
+
     if len(set(input_ext)) > 1:
         util.fatal_error_main(f"Please specify either: A single .bam/.cram file - OR - one or more .snf files - OR - a single .tsv file containing a list of .snf files and optional sample ids as input. (supplied were: {list(set(input_ext))})")
 


### PR DESCRIPTION
The defaults of multiprocessing are [platform dependent](https://docs.python.org/3.8/library/multiprocessing.html#contexts-and-start-methods), and the defaults for OSX and windows are different from those of unix. Furthermore, the code is currently written and tested assuming the "fork" (versus "spawn") method of creating new threads, and running the code on OSX leads to exceptions (see #498) 

This PR simply changes the start-method to use "fork" which resolves the issue (for me) 

closes #498 