### PR TITLE
Optionally emit SV lengths

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='sniffles',
-    version='2.4',
+    version='2.4.1',
     packages=find_packages(),
     url='https://github.com/fritzsedlazeck/Sniffles',
     license='MIT',

--- a/src/sniffles/config.py
+++ b/src/sniffles/config.py
@@ -3,7 +3,7 @@
 # Sniffles2
 # A fast structural variant caller for long-read sequencing data
 #
-# Created:     18.10.2021
+# Created: 18.10.2021
 # Author:      Moritz Smolka
 # Maintainer:  Hermann Romanek
 # Contact:     sniffles@romanek.at
@@ -13,7 +13,6 @@ import os
 import sys
 import datetime
 import argparse
-from collections import defaultdict
 
 from typing import Union, Optional
 
@@ -21,7 +20,7 @@ from sniffles import util
 from sniffles.region import Region
 
 VERSION = "Sniffles2"
-BUILD = "2.4"
+BUILD = "2.4.1"
 SNF_VERSION = "S2_rc4"
 
 

--- a/src/sniffles/config.py
+++ b/src/sniffles/config.py
@@ -224,6 +224,8 @@ class SnifflesConfig(argparse.Namespace):
 
     def add_developer_args(self, parser):
         developer_args = parser.add_argument_group("Developer parameters")
+
+        developer_args.add_argument("--dev-emit-sv-lengths", default=False, action="store_true", help=argparse.SUPPRESS)
         developer_args.add_argument("--dev-cache", default=False, action="store_true", help=argparse.SUPPRESS)
         developer_args.add_argument("--dev-cache-dir", metavar="PATH", type=str, default=None, help=argparse.SUPPRESS)
         developer_args.add_argument("--dev-debug-svtyping", default=False, action="store_true", help=argparse.SUPPRESS)

--- a/src/sniffles/sv.py
+++ b/src/sniffles/sv.py
@@ -49,6 +49,7 @@ class SVCall:
 
     svtype: str
     svlen: int
+    svlens: list[int]
     end: int
     genotypes: dict[int, tuple]
 
@@ -268,6 +269,9 @@ class SVGroup:
 
         svcall_pos = int(util.median(cand.pos for cand in self.candidates))
         svcall_svlen = int(util.median(cand.svlen for cand in self.candidates))
+        svcall_svlens: list[int] = [length in cand_lengths
+                                        for cand_lengths in self.candidates
+                                        for length in cand_lengths.svlens]
         svcall_alt = first_cand.alt
         svcall_alt_mindist = abs(len(svcall_alt) - svcall_svlen)
         if first_cand.svtype == "INS":
@@ -290,6 +294,7 @@ class SVGroup:
                         info=dict(),
                         svtype=first_cand.svtype,
                         svlen=svcall_svlen if config.dev_combine_medians else first_cand.svlen,
+                        svlens=svcall_svlens,
                         end=svcall_end if config.dev_combine_medians else first_cand.end,
                         genotypes=genotypes,
                         precise=sum(int(cand.precise) for cand in self.candidates) / float(len(self.candidates)) > 0.5,
@@ -338,7 +343,7 @@ def call_from(cluster, config, keep_qc_fails, task):
     qc = True
 
     svlen = util.center(v.svlen for v in leads)
-
+    svlens = [v.svlen for v in leads]
     if abs(svlen) < config.minsvlen_screen:
         return
 
@@ -394,6 +399,7 @@ def call_from(cluster, config, keep_qc_fails, task):
                     info=dict(),
                     svtype=svtype,
                     svlen=svlen,
+                    svlens=svlens,
                     end=svend,
                     genotypes=dict(),
                     precise=precise,

--- a/src/sniffles/vcf.py
+++ b/src/sniffles/vcf.py
@@ -81,6 +81,9 @@ class VCF:
         if config.qc_nm_measure:
             self.info_order.append("NM")
 
+        if config.dev_emit_sv_lengths:
+            self.info_order.append("SVLENGTHS")
+
         self.default_genotype = config.genotype_none
 
         # Add phasing if needed
@@ -151,6 +154,7 @@ class VCF:
         self.write_header_line('INFO=<ID=IMPRECISE,Number=0,Type=Flag,Description="Structural variation with imprecise breakpoints">')
         self.write_header_line('INFO=<ID=MOSAIC,Number=0,Type=Flag,Description="Structural variation classified as putative mosaic">')
         self.write_header_line('INFO=<ID=SVLEN,Number=1,Type=Integer,Description="Length of structural variation">')
+        self.write_header_line('INFO=<ID=SVLENGTHS,Number=.,Type=Integer,Description="Lengths of structural variation (all)">')
         self.write_header_line('INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variation">')
         self.write_header_line('INFO=<ID=CHR2,Number=1,Type=String,Description="Mate chromsome for BND SVs">')
         self.write_header_line('INFO=<ID=SUPPORT,Number=1,Type=Integer,Description="Number of reads supporting the structural variation">')
@@ -218,6 +222,7 @@ class VCF:
         infos = {
             "SVTYPE": call.svtype,
             "SVLEN": call.svlen,
+            "SVLENGTHS": ",".join(map(str, call.svlens)),
             "END": end,
             "SUPPORT": call.support,
             "RNAMES": call.rnames if self.config.output_rnames else None,
@@ -229,6 +234,7 @@ class VCF:
 
         if call.svtype == "BND":
             infos["SVLEN"] = None
+            infos["SVLENGTHS"] = None
             infos["END"] = None
 
         infos_ordered = ["PRECISE" if call.precise else "IMPRECISE"]

--- a/src/sniffles/vcf.py
+++ b/src/sniffles/vcf.py
@@ -154,7 +154,7 @@ class VCF:
         self.write_header_line('INFO=<ID=IMPRECISE,Number=0,Type=Flag,Description="Structural variation with imprecise breakpoints">')
         self.write_header_line('INFO=<ID=MOSAIC,Number=0,Type=Flag,Description="Structural variation classified as putative mosaic">')
         self.write_header_line('INFO=<ID=SVLEN,Number=1,Type=Integer,Description="Length of structural variation">')
-        self.write_header_line('INFO=<ID=SVLENGTHS,Number=.,Type=Integer,Description="Lengths of structural variation (all)">')
+        self.write_header_line('INFO=<ID=SVLENGTH,Number=.,Type=Integer,Description="Lengths of structural variation (all)">')
         self.write_header_line('INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variation">')
         self.write_header_line('INFO=<ID=CHR2,Number=1,Type=String,Description="Mate chromsome for BND SVs">')
         self.write_header_line('INFO=<ID=SUPPORT,Number=1,Type=Integer,Description="Number of reads supporting the structural variation">')
@@ -349,6 +349,9 @@ class VCF:
 
                 if "SVLEN" in info_dict:
                     call.svlen = int(info_dict["SVLEN"])
+                if "SVLENGTHS`" in info_dict:
+                    call.svlens = info_dict["SVLENGTHS"]
+
                 if "END" in info_dict:
                     call.end = int(info_dict["END"])
 


### PR DESCRIPTION
closes #503 

This PR adds a commandline argument that emits the lengths of the SVs found on the reads into the VCF record that contains the resulting SV. The argument is suppressed (not showing in the "help") and is prefixed with `dev-` to indicate that it's a development/debugging option.

The only change to the output is the (currently non-optional) addition of the `SVLENGTHS` header line in the VCF. However, I'm happy to make this also optional. otherwise, the algorithm and output are unchanged unless `--dev-emit-sv-lengths` is provided on the command-line.