### PR TITLE
Update vcf.py to have correct END value for DEL SVTYPE

### DIFF
--- a/src/sniffles/vcf.py
+++ b/src/sniffles/vcf.py
@@ -230,7 +230,7 @@ class VCF:
             "SVTYPE": call.svtype,
             "SVLEN": call.svlen,
             "SVLENGTHS": ",".join(map(str, call.svlens)) if call.svlens else None,
-            "END": end,
+            "END": end + 1,
             "SUPPORT": call.support,
             "RNAMES": call.rnames if self.config.output_rnames else None,
             "COVERAGE": f"{call.coverage_upstream},{call.coverage_start},{call.coverage_center},{call.coverage_end},"

--- a/src/sniffles/vcf.py
+++ b/src/sniffles/vcf.py
@@ -230,7 +230,7 @@ class VCF:
             "SVTYPE": call.svtype,
             "SVLEN": call.svlen,
             "SVLENGTHS": ",".join(map(str, call.svlens)) if call.svlens else None,
-            "END": end + 1,
+            "END": end,
             "SUPPORT": call.support,
             "RNAMES": call.rnames if self.config.output_rnames else None,
             "COVERAGE": f"{call.coverage_upstream},{call.coverage_start},{call.coverage_center},{call.coverage_end},"
@@ -243,6 +243,10 @@ class VCF:
             infos["SVLEN"] = None
             infos["SVLENGTHS"] = None
             infos["END"] = None
+
+        if call.svtype == "DEL":
+            # END is POS + length of REF allele - 1
+            infos["END"] = end - 1
 
         infos_ordered = ["PRECISE" if call.precise else "IMPRECISE"]
         af = call.get_info("AF")


### PR DESCRIPTION
Fixes fritzsedlazeck/Sniffles#405 
ENV values are 1-based in the VCF spec, so the END = POS for a 1-letter reference, and END = POS + (length_of_reference - 1) in the general case.