### PR TITLE
Ensure tasks deque is empty after workers exit

### DIFF
--- a/src/sniffles/sniffles
+++ b/src/sniffles/sniffles
@@ -503,6 +503,11 @@ def Sniffles2_Main(processes: list[parallel.SnifflesWorker]):
     log.info(f"Took {time.monotonic() - analysis_start_time:.2f}s.")
     log.info("")
 
+    # It is possible that workers have all exited without finishing all work
+    # Check the tasks deque is actually empty and explode accordingly if not
+    if len(tasks) > 0:
+        util.fatal_error_main("All workers have exited but work remains to be done, it is possible that all workers have been killed by your system due to memory constraints.")
+
     finished_tasks.sort(key=lambda task: task.id)
 
     for t in finished_tasks:


### PR DESCRIPTION
Recent testing of Sniffles 2.6.2 inside a cgroup led to the invocation of the OOM-killer on worker processes. As expected, each worker was found dead by the heartbeat loop and its in-progress work was cleanly returned to the deque. However, *all* our worker processes were OOM-killed leaving no workers left to compute tasks from the deque.

There is no check to ensure that all tasks have been computed once all workers have exited. After the death of all our worker processes, Sniffles 2.6.2 produced a VCF file with a header and no variants, and happily exits with a zero exit status.

This change checks the length of the task deque to ensure no work remains on the queue once all workers have exited; and raises a fatal error if tasks have been found, to advise the user that the likely scenario was termination of all workers.