### PR TITLE
Fix the occurrence of `None` in `INFO/COVERAGE` (#568)

### DIFF
--- a/src/sniffles/util.py
+++ b/src/sniffles/util.py
@@ -83,6 +83,10 @@ def trim(nums, pct=25):
     else:
         return nums
 
+def optional_value(val):
+    if val is None:
+        return '.'
+    return str(val)
 
 def most_common(nums):
     counts = {}

--- a/src/sniffles/vcf.py
+++ b/src/sniffles/vcf.py
@@ -256,7 +256,7 @@ class VCF:
             "END": end,
             "SUPPORT": call.support,
             "RNAMES": call.rnames if self.config.output_rnames else None,
-            "COVERAGE": ",".join(util.optional_value, [call.coverage_upstream, call.coverage_start, call.coverage_center, call.coverage_end, call.coverage_downstream]),
+            "COVERAGE": ",".join(map(util.optional_value, [call.coverage_upstream, call.coverage_start, call.coverage_center, call.coverage_end, call.coverage_downstream])),
             "STRAND": ("+" if call.fwd > 0 else "") + ("-" if call.rev > 0 else ""),
             "NM": call.nm
         }

--- a/src/sniffles/vcf.py
+++ b/src/sniffles/vcf.py
@@ -256,8 +256,7 @@ class VCF:
             "END": end,
             "SUPPORT": call.support,
             "RNAMES": call.rnames if self.config.output_rnames else None,
-            "COVERAGE": f"{call.coverage_upstream},{call.coverage_start},{call.coverage_center},{call.coverage_end},"
-                        f"{call.coverage_downstream}",
+            "COVERAGE": ",".join(util.optional_value, [call.coverage_upstream, call.coverage_start, call.coverage_center, call.coverage_end, call.coverage_downstream]),
             "STRAND": ("+" if call.fwd > 0 else "") + ("-" if call.rev > 0 else ""),
             "NM": call.nm
         }


### PR DESCRIPTION
Trivial fix: serialise `None` as `.`, rather than `None`.