### PR TITLE
Reduce memory usage of SV postprocessing

### DIFF
--- a/src/sniffles/postprocessing.py
+++ b/src/sniffles/postprocessing.py
@@ -212,8 +212,7 @@ def coverage_fulfill(calls, requests_for_coverage_attrs, requests_for_coverage_s
         if bin_pos in requests_for_coverage_sample_starts:
             if bin_modulus not in bin_moduli:
                 bin_moduli[bin_modulus] = set()
-            to_open = list(requests_for_coverage_sample_starts[bin_pos])
-            bin_moduli[bin_modulus].update(to_open)
+            bin_moduli[bin_modulus].update(requests_for_coverage_sample_starts[bin_pos])
 
         # sample welfordly
         for sv_i in bin_moduli.get(bin_modulus, []):
@@ -222,9 +221,7 @@ def coverage_fulfill(calls, requests_for_coverage_attrs, requests_for_coverage_s
         # close
         # this is the last bin, do not process any more overlaps on the next iteration
         if bin_pos in requests_for_coverage_sample_ends:
-            to_close = list(requests_for_coverage_sample_ends[bin_pos])
-            for sv_i in to_close:
-                bin_moduli[bin_modulus].remove(sv_i)
+            bin_moduli[bin_modulus].difference_update(requests_for_coverage_sample_ends[bin_pos])
 
         coverage_fwd_total += coverage_fwd
         coverage_rev_total += coverage_rev


### PR DESCRIPTION
Further to #565, I have been able to pinpoint the excessive use of memory during SV calling to the functionality introduced to postprocessing.coverage in Sniffles 2.6.2. Applying this patch should reduce peak RSS by 10 - 20x and allow Sniffles to be run on larger numbers of SVs efficiently.

## Background
Coverage postprocessing is conducted in two steps, for each contig, by each worker:
- Build: Inspect all SVCalls and generate a manifest of positions from which to sample coverage.
- Fulfill: Traverse the coverage structure from start to end and execute the coverage requests.

Sniffles 2.6.2 added a new type of "sampling point" request which samples points every config.large_coverage_sample_interval for all SVs larger than config.large_del_length. However, when Sniffles 2.6.2 encounters many large SVs, both the build and fulfill steps become unsustainable.

## Problem
During the build step: Each 100 bp coverage bin is associated to a list of functools.partial. Each partial binds the new SVCall.add_coverage_sample function to the coverage bin index and appends it to a list to be executed later during fulfillment [1]. On one of our HG003 datasets [2] the build step generates 20.8 M functools.partials across 31 K SVCalls: using 3.5 GB of RAM to do so. This new cost is exacerbated by the 4 default workers and in this case the first four contigs to be analysed together require storage of 61.4 M functools.partials, costing 10.6 GB. This may not seem a lot, but 10 GB to store lists of partial functions alone greatly exceeds the resident memory (peak RSS) of the entire Sniffles 2.6.1 SV calling which anecdotally used 3 - 5 GB.

Once the requests have been enumerated, they are fulfilled by traversing the contig coverage bins from start to end, querying the coverage structure for the coverage at this particular bin and executing the associated functools.partials.
However, every call to SVCall.add_coverage_sample adds a dict entry of the SVCall of the current bin position to the observed coverage: costing around 8 bytes per push for the two numbers and some nebulous overhead for the dictionary hashes itself. On our HG003 dataset chr1 requires an additional 1.5 GB to store the fulfilled coverage observations.

Combined, the requests and fulfillment over the first four contigs use at least 15 GB of RAM just to handle the additional sampling points for large intervals - this does not include the overhead of the SVCall objects, or the coverage table.
These numbers are what can be directly attributed to these structures with pympler.asizeof but in practice when looking at peak RSS from outside the program the problem is more pronounced. Peak RSS was 30.1 GB for the HG003 dataset, which is 5 times more than the recommended upper resource limit of 6 GB that we had in place for previous versions of Sniffles.

## Problem but bigger
While we could have plausibly increased our minimum resource requirement for Sniffles to 32 GB going forward, the crux of this MR is that on larger numbers of SVs, these steps turn out to be intractable, even with a somewhat unreasonable computer. We have encountered a sample that was OOM killed with a single worker consuming all RAM on a 96 GB RAM instance with a single worker. For chr1 of this "intractable sample", the build step generates 217 M functools.partials across 171 K SVCalls. 20 minutes of inserting coverage observations to each SVCall.coverage_samples dict later, the worker is killed for consuming all memory on the instance.

I also note that even if I had enough memory to run Sniffles 2.6.2 on this data set, it looks like there would be an impact to runtime as the time taken to execute all partials increased an order of magnitude from an average of 0.04 s/M bins (across our HG003 sample) to 0.67 s/M bins (on what we managed of the intractable sample).

Anecdotally, the user who first alerted us to this sensibly intractable case claims to have been able to analyse this data in 13 hours with 128 GB RAM. The need for this much memory significantly hampers performance (as we can only run one worker rather than 4 or more, and the sheer number of partials appear to slow us down) and portability of the program (as most commodity computers do not have sufficient memory).

I understand now that this is what was observed in the discovery of #565; workers are killed as they compete to fill available memory with partial functions and coverage observations, eventually leaving only one worker free to consume as much RAM as possible before it too is finally reaped by the OOM killer.

## Observations
Luckily - there is low hanging fruit here and this MR recognises some useful properties of the 2.6.2 sampling point strategy:
- The start and end of the SVCall are translated to use the lowest appropriate 100 bp coverage bin.
- The 5000 bp large_coverage_sample_interval stride is deterministic along these 100 bp coverage bins.
- Fulfillment only uses these 100 bp coverage bins.

As fulfillment traverses start to end along these 100 bp bins and the 5000 bp large_coverage_sample_interval is predictable:
- We do not need to store the positions to be sampled ahead of time at all; because the first and last bin for the SVCall already define the boundary of coverage sampling, and the known large_coverage_sample_interval stride defines a fixed sampling periodicity.
- The modulo of a bin with respect to the large_coverage_sample_interval is the same for all bins in that stride.

Both of these allow for an implementation that mitigates the cost of the build step. To alleviate the fulfillment step we observe we observe that postprocessing.coverage requires only the variance of a list of numbers for the SVCall and that for the forward difference the position of the coverage observations do not matter, only the order. We can apply Welford's algorithm to calculate the forward difference variance online, mitigating the cost of the fulfillment step.

## Implementation
Briefly, this MR changes:
- Build: To store only the corresponding first and last 100 bp bin for each SVCall, rather than all bins. I've also updated the original coverage requests to use an IntEnum to indicate what SVCall attr should be updated during fulfillment such that no functools.partials are required at all. I have not considered the impact of these partials in my descriptions above but they too become non-negligible to store in the intractable sample case (856 K partials).
- Fulfill: To map the modulus of all first bins to the index of SVCall objects within the list of calls, allowing for fast determination of which SVCalls to update for each bin.
- SVCall: To implement Welford's algorithm, offering a push method to be called during fulfillment that will update the online variance, rather than storing all coverage observations.

## Validity
There are no unit tests to corroborate a successful implementation, but results remain consistent in my limited manual testing:
- I've compared the variances for all SVCalls using both the Welford method and the existing numpy diffs, they are often not equal but they are sufficiently `np.allclose`. Welford is known to be numerically stable and I figure it is not unexpected that an online approach will accumulate a level of precision error differently to the numpy batch approach.
- With the exception of RNAMES, the VCF generated by Sniffles 2.6.2 and the version in this MR are the same on our HG003 data set.
- Sniffles 2.6.2 can now be run on our intractable dataset.

## Performance
- We're now able to run HG003 with a peak RSS of 2.8 GB, a nearly 11x smaller footprint.
- This implementation also has a bonus benefit of being a little faster: running around 15% faster than Sniffles 2.6.2 on HG003.
- The intractable case is now tractable: we're able to run Sniffles to completion with the default 4 threads in 23.2 minutes and a peak RSS of 5.0 GB, rather than crashing on 96 GB: a ~20x memory footprint improvement.

## Open questions
- While checking my implementation provided the same variances as the existing code, I found that the existing approach is prone to returning very large variances (>1e20). This is due to the use of 1e-10 to avoid any division by zero when calculating the forward difference [5], leading to very large relative differences away from zero. I suspect the presence of these values may adversely affect the qc_coverage_samples check for variance <0.3 [6]. In my limited exploring I found that falling back to the absolute difference yields numerically robust results.
- While changing coverage_fulfill, I noticed that coverage_fwd [7] and coverage_rev [8] are accumulated across all bins. I first thought that this was to ensure that the relative forward difference are always >= 0; but then these values are themselves accumulated by coverage_fwd_total and coverage_rev_total [9]. This appears to be a bug and would cause the total counts to be triangularly inflated?
- During testing I discovered a handful of my SVCall objects had a negative pos. To obtain the same sample coverage variance as the existing implementation I had to adjust the start position in these cases to find the first positive first bin that would be hit when striding from this negative start position. Are negative pos expected?

--

[1] https://github.com/fritzsedlazeck/Sniffles/blame/v2.6.2/src/sniffles/postprocessing.py#L82
[2] https://epi2me.nanoporetech.com/giab-2025.01/
[3] https://github.com/fritzsedlazeck/Sniffles/blame/v2.6.2/src/sniffles/postprocessing.py#L160
[4] https://github.com/fritzsedlazeck/Sniffles/blame/v2.6.2/src/sniffles/sv.py#L97
[5] https://github.com/fritzsedlazeck/Sniffles/blame/v2.6.2/src/sniffles/sv.py#L110
[6] https://github.com/fritzsedlazeck/Sniffles/blame/v2.6.2/src/sniffles/sv.py#L112
[7] https://github.com/fritzsedlazeck/Sniffles/blame/v2.6.2/src/sniffles/postprocessing.py#L152
[8] https://github.com/fritzsedlazeck/Sniffles/blame/v2.6.2/src/sniffles/postprocessing.py#L155
[9] https://github.com/fritzsedlazeck/Sniffles/blame/v2.6.2/src/sniffles/postprocessing.py#L162-L163