### PR TITLE
merge in de novo updates

### DIFF
--- a/src/sniffles/config.py
+++ b/src/sniffles/config.py
@@ -246,8 +246,7 @@ class SnifflesConfig(argparse.Namespace):
 
     mosaic_include_germline: bool
     mosaic_qc_nm: bool
-    # TODO some better rules here
-    mosaic_min_reads: int
+    mosaic_min_reads: int # remove hard-coded minimum reads
     mosaic_use_strand_thresholds: int = 10
 
     @staticmethod

--- a/src/sniffles/config.py
+++ b/src/sniffles/config.py
@@ -225,12 +225,13 @@ class SnifflesConfig(argparse.Namespace):
     mosaic_include_germline: bool
     mosaic_qc_nm: bool
     # TODO some better rules here
-    mosaic_min_reads: int = 3
+    mosaic_min_reads: int
     mosaic_use_strand_thresholds: int = 10
 
     def add_mosaic_args(self, parser):
         mosaic_args = parser.add_argument_group("Mosaic calling mode parameters")
         mosaic_args.add_argument("--mosaic", help="Set Sniffles run mode to detect rare, somatic and mosaic SVs", default=False, action="store_true")
+        mosaic_args.add_argument("--mosaic-min-reads", help="Minimum number of reads required to call a mosaic SV", metavar="N", default=1, type=int)
         mosaic_args.add_argument("--mosaic-af-max", help="Maximum allele frequency for which SVs are considered mosaic", metavar="F", default=0.218, type=float)
         mosaic_args.add_argument("--mosaic-af-min", help="Minimum allele frequency for mosaic SVs to be output", metavar="F", default=0.05, type=float)
         mosaic_args.add_argument("--mosaic-qc-invdup-min-length", help="Minimum SV length for mosaic inversion and duplication SVs", metavar="N", default=500, type=int)

--- a/src/sniffles/postprocessing.py
+++ b/src/sniffles/postprocessing.py
@@ -382,7 +382,7 @@ def qc_sv_post_annotate(svcall: SVCall, config: SnifflesConfig):
     qc_nm_threshold = config.qc_nm_threshold * config.qc_nm_mult
     if config.mosaic and sv_is_mosaic:
         qc_nm = config.mosaic_qc_nm
-        qc_nm_threshold = config.qc_nm_threshold * config.qc_nm_mult
+        qc_nm_threshold = max(config.qc_nm_threshold * config.qc_nm_mult, 0.001)
     if qc_nm and svcall.nm > qc_nm_threshold and (len(svcall.genotypes) == 0 or svcall.genotypes[0][1] == 0):
         svcall.filter = "ALN_NM"
         svcall.set_info("QC_NM_THRESHOLD", qc_nm_threshold)

--- a/src/sniffles/postprocessing.py
+++ b/src/sniffles/postprocessing.py
@@ -385,6 +385,7 @@ def qc_sv_post_annotate(svcall: SVCall, config: SnifflesConfig):
         qc_nm_threshold = config.qc_nm_threshold * config.qc_nm_mult
     if qc_nm and svcall.nm > qc_nm_threshold and (len(svcall.genotypes) == 0 or svcall.genotypes[0][1] == 0):
         svcall.filter = "ALN_NM"
+        svcall.set_info("QC_NM_THRESHOLD", qc_nm_threshold)
         return False
 
     if config.mosaic:

--- a/src/sniffles/postprocessing.py
+++ b/src/sniffles/postprocessing.py
@@ -382,7 +382,7 @@ def qc_sv_post_annotate(svcall: SVCall, config: SnifflesConfig):
     qc_nm_threshold = config.qc_nm_threshold * config.qc_nm_mult
     if config.mosaic and sv_is_mosaic:
         qc_nm = config.mosaic_qc_nm
-        qc_nm_threshold = max(config.qc_nm_threshold * config.qc_nm_mult, 0.001)
+        qc_nm_threshold = max(config.qc_nm_threshold * config.qc_nm_mult, 0.005)
     if qc_nm and svcall.nm > qc_nm_threshold and (len(svcall.genotypes) == 0 or svcall.genotypes[0][1] == 0):
         svcall.filter = "ALN_NM"
         svcall.set_info("QC_NM_THRESHOLD", qc_nm_threshold)

--- a/src/sniffles/vcf.py
+++ b/src/sniffles/vcf.py
@@ -176,6 +176,7 @@ class VCF:
         self.write_header_line('INFO=<ID=RNAMES,Number=.,Type=String,Description="Names of supporting reads (if enabled with --output-rnames)">')
         self.write_header_line('INFO=<ID=VAF,Number=1,Type=Float,Description="Variant Allele Fraction">')
         self.write_header_line('INFO=<ID=NM,Number=.,Type=Float,Description="Mean number of query alignment length adjusted mismatches of supporting reads">')
+        self.write_header_line('INFO=<ID=QC_NM_THRESHOLD,Number=.,Type=Float,Description="Local NM threshold used for filtering">')
         self.write_header_line('INFO=<ID=PHASE,Number=.,Type=String,Description="Phasing information derived from supporting reads, represented as list of: HAPLOTYPE,PHASESET,HAPLOTYPE_SUPPORT,PHASESET_SUPPORT,HAPLOTYPE_FILTER,PHASESET_FILTER">')
 
         samples_header = "\t".join(sample_id for _, sample_id in self.config.sample_ids_vcf)


### PR DESCRIPTION
* Removes the hard-coded `mosaic_min_reads` setting (3 reads), re-enabling configuration with `--mosaic-min-reads`.
* Updates `qc_nm_threshold` with a floor value of 0.005, accomodating low NM values expected with self-alignment.
* Adds a new `QC_NM_THRESHOLD` tag to the `INFO` field that describes the calculated NM threshold, useful for comparing NM QC failures.